### PR TITLE
Add prevent_sudo

### DIFF
--- a/machine_puppet.json
+++ b/machine_puppet.json
@@ -11,7 +11,8 @@
         },
         {
             "type": "puppet-masterless",
-            "manifest_file": "manifests/default.pp"
+            "manifest_file": "manifests/default.pp",
+            "prevent_sudo": true
         }
     ],
     "post-processors": [


### PR DESCRIPTION
ubuntu:latest does not contain `sudo`.

```
==> docker: Provisioning with Puppet...
    docker: Creating Puppet staging directory...
    docker: Uploading manifests...
    docker: Uploading manifest file from: manifests/default.pp
    docker: Running Puppet: cd /tmp/packer-puppet-masterless && FACTER_packer_builder_type='docker' FACTER_packer_build_name='docker'  sudo -E puppet apply --verbose --modulepath='' --detailed-exitcodes /tmp/packer-puppet-masterless/manifests/default.pp
    docker: /bin/sh: 1: sudo: not found
```